### PR TITLE
ci: goreleaser binaries + readme restructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
+
+      - name: Check for new tag
+        id: tag
+        run: |
+          TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
+          echo "new=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Go
+        if: steps.tag.outputs.new != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        if: steps.tag.outputs.new != ''
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+version: 2
+
+builds:
+  - main: .
+    binary: ghset
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  mode: append

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,22 +33,6 @@ go run . describe thumbrise/ghset
 go run . init my-repo --from config.yml
 ```
 
-## Project structure
-
-```
-main.go                Entry point
-cmd/
-  root.go              Cobra root command
-  describe.go          describe command — snapshot repo → YAML
-  init.go              init command — create repo from YAML
-internal/
-  config/              YAML config struct + marshal/unmarshal
-  gh/                  Wrapper around `gh api` subprocess
-  prompt/              huh-based interactive prompts
-_tools/                Dev tools: license-eye, govulncheck (separate go.mod)
-docs/                  VitePress documentation site
-```
-
 ## Commit messages
 
 Conventional commits. English only.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 
   themeConfig: {
     nav: [
-      {text: 'Why ghset?', link: '/why'},
+      {text: 'Guide', link: '/guide'},
       {text: 'Devlog', link: '/devlog/'},
       {text: 'GitHub', link: 'https://github.com/thumbrise/ghset'},
     ],
@@ -34,6 +34,7 @@ export default defineConfig({
         {
           text: 'Guide',
           items: [
+            {text: 'Guide', link: '/guide'},
             {text: 'Why ghset?', link: '/why'},
           ],
         },

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,20 +1,17 @@
-# ghset
+---
+title: "Guide — ghset"
+description: "Install ghset and copy GitHub repository settings in one command."
+head:
+  - - meta
+    - name: keywords
+      content: github repository settings cli, ghset install, ghset guide, copy github repo settings, declarative github config
+---
 
-[![CI](https://github.com/thumbrise/ghset/actions/workflows/ci.yml/badge.svg)](https://github.com/thumbrise/ghset/actions/workflows/ci.yml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/thumbrise/ghset.svg)](https://pkg.go.dev/github.com/thumbrise/ghset)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](/LICENSE)
+# Guide
 
-Declarative GitHub repository settings. Describe an existing repo into YAML, spin up a new repo from that YAML.
+## Install
 
-## Why
-
-Every new GitHub repo starts with the same ritual: click through settings, toggle security options, recreate labels, set up branch protection. Multiply that by 10 repos and it's a whole afternoon. **ghset** turns all of that into one command.
-
-## Quick start
-
-Prerequisites: [gh CLI](https://cli.github.com/) installed and authenticated (`gh auth login`).
-
-### Install
+Only prerequisite: [gh CLI](https://cli.github.com/) installed and authenticated (`gh auth login`).
 
 **macOS / Linux**
 ```bash
@@ -28,7 +25,7 @@ go install github.com/thumbrise/ghset@latest
 
 **Manual** — grab a binary from [Releases](https://github.com/thumbrise/ghset/releases/latest).
 
-### Run
+## Quick start
 
 ```bash
 ghset init my-new-repo --from thumbrise/ghset
@@ -44,19 +41,19 @@ That's it. The new repo gets everything copied:
 
 ```bash
 # Snapshot repo settings → YAML
-ghset describe thumbrise/ghset > config.yml
+ghset describe owner/repo > config.yml
 
 # Create new repo from config
 ghset init my-new-repo --from config.yml
 
 # Or directly from another repo — no intermediate file
-ghset init my-new-repo --from thumbrise/ghset
+ghset init my-new-repo --from owner/repo
 
 # Apply config to an existing repo
-ghset apply thumbrise/ghset --from config.yml
+ghset apply owner/repo --from config.yml
 
 # Pipe — describe one, create another
-ghset describe thumbrise/ghset | ghset init my-new-repo
+ghset describe owner/repo | ghset init my-new-repo
 ```
 
 | Command | What it does |
@@ -65,14 +62,38 @@ ghset describe thumbrise/ghset | ghset init my-new-repo
 | `init` | Create new repo + apply settings |
 | `apply` | Apply settings to existing repo |
 
+## Config format
+
+Single YAML format — `describe` writes it, `init` and `apply` read it:
+
+```yaml
+settings:
+  visibility: public
+  allow_rebase_merge: true
+  delete_branch_on_merge: true
+
+security:
+  secret_scanning: true
+  vulnerability_alerts: true
+
+labels:
+  - name: "T: bug"
+    color: "d73a4a"
+    description: "Something isn't working"
+
+rulesets:
+  - name: "main"
+    target: branch
+    enforcement: active
+    rules:
+      - type: deletion
+      - type: pull_request
+        parameters:
+          required_approving_review_count: 1
+```
+
 ## How it works
 
 All GitHub API calls go through `gh` CLI as a subprocess. No tokens in the tool, no OAuth — `gh` handles auth entirely.
 
-## Docs & rationale
-
-**[thumbrise.github.io/ghset](https://thumbrise.github.io/ghset/)** — full docs, [why not Terraform / Probot / safe-settings](https://thumbrise.github.io/ghset/why), devlog.
-
-## License
-
-Apache 2.0
+No state files. No infrastructure. Just settings, copied.

--- a/docs/why.md
+++ b/docs/why.md
@@ -55,29 +55,3 @@ The `describe` direction — snapshotting a repo into a portable config — does
 | Setup time | 0 (uses `gh`) | Hours (HCL + state) | 0 |
 | Infrastructure | None | State file + backend | None |
 | Learning curve | 2 commands | Terraform language | Click UI |
-
-## Install
-
-```bash
-go install github.com/thumbrise/ghset@latest
-```
-
-Only prerequisite: [gh CLI](https://cli.github.com/) installed and authenticated.
-
-## Usage
-
-```bash
-# Describe → YAML
-ghset describe owner/repo > settings.yml
-
-# Init from file
-ghset init new-repo --from settings.yml
-
-# Init directly from another repo
-ghset init new-repo --from owner/repo
-
-# Pipe
-ghset describe owner/repo | ghset init new-repo
-```
-
-No tokens. No state files. No infrastructure. Just settings, copied.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+REPO="thumbrise/ghset"
+BINARY="ghset"
+INSTALL_DIR="/usr/local/bin"
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  arm64)   ARCH="arm64" ;;
+  *)
+    echo "Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+case "$OS" in
+  linux|darwin) ;;
+  *)
+    echo "Unsupported OS: $OS (use Go install or download from Releases)" >&2
+    exit 1
+    ;;
+esac
+
+URL="https://github.com/${REPO}/releases/latest/download/${BINARY}_${OS}_${ARCH}.tar.gz"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Downloading ${BINARY} for ${OS}/${ARCH}..."
+curl -sfL "$URL" -o "${TMPDIR}/${BINARY}.tar.gz"
+tar xz -C "$TMPDIR" -f "${TMPDIR}/${BINARY}.tar.gz" "$BINARY"
+
+sudo mkdir -p "$INSTALL_DIR"
+sudo mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+
+echo "Installed ${BINARY} to ${INSTALL_DIR}/${BINARY}"


### PR DESCRIPTION
## What
- GoReleaser: cross-platform binaries (linux/darwin/windows × amd64/arm64) attached to GitHub Releases
- README: restructured — why, quick start with curl/go install, commands table
- VitePress: split into guide.md (install + usage) and why.md (rationale + comparison)
- CONTRIBUTING.md: removed project structure section (outdated by design)
## Release workflow
semantic-release creates tag + GitHub Release → GoReleaser builds binaries and appends to the same Release. Gated: GoReleaser only runs when a new tag exists.
## Install options
- `curl` one-liner (macOS/Linux)
- `go install`
- Manual binary from Releases